### PR TITLE
Check device ID for set_auto_reboot

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,8 @@ in order to activate the auto reboot on power failure setting.
 
 This has been tested on a Mac mini 2011.
 
-**WARNING!** The utility does no checking of what card it actually talking to. If you run this on a machine with a different device at that address the results are not defined and could cause permanent damage to your hardware. Only use this if you know what you are doing and use at own risk.
+This script will now check that the chip id is infact the one listed above to prevent it from running on the wrong type of machine
+
 
 Usage
 -----

--- a/rc.d/set_auto_reboot
+++ b/rc.d/set_auto_reboot
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# the before line below is probably not the right way to do this but I can't
+# figure out how to force this script to be started as the very first one
+
+# PROVIDE: set_auto_reboot
+# REQUIRE:
+# BEFORE: growfs 
+# KEYWORD: 
+#
+
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# set_auto_rebot_enable (bool):	Set to NO by default.
+#			Set it to YES to enable tpmd.
+
+. /etc/rc.subr
+
+name="set_auto_reboot"
+rcvar=`set_rcvar`
+
+start_cmd="${name}_start"
+stop_cmd=":"
+
+load_rc_config $name
+: ${set_auto_reboot_enable:=no}
+: ${set_auto_reboot_msg="Nothing started."}
+
+
+set_auto_reboot_start ()
+{
+	/sbin/set_auto_reboot
+	echo "auto_reboot set"
+}
+
+run_rc_command "$1"

--- a/set_auto_reboot.c
+++ b/set_auto_reboot.c
@@ -20,9 +20,23 @@ int main() {
 	d.pi_sel.pc_bus = 0;
 	d.pi_sel.pc_dev = 3;
 	d.pi_sel.pc_func = 0;
+	d.pi_reg = 0x00;		// read the device and vendor IDs
+	d.pi_width = 4;
+
+	ret = ioctl(f, PCIOCREAD, &d);
+	if (ret != 0) {
+		perror("Unable to perform PCIOCREAD for device and vendor ID");
+		exit(3);
+	} else {
+		if (d.pi_data != 0x0d8010de){
+			printf ("device not found, expecting 0xd8010de found 0x%x\n", d.pi_data);
+			exit (5);
+		}
+	}
+
 	d.pi_reg = 0x7b;
 	d.pi_width = 1;
-
+	
 	ret = ioctl(f, PCIOCREAD, &d);
 	if (ret != 0) {
 		perror("Unable to perform PCIOCREAD");


### PR DESCRIPTION
Nicholas,
Per our email conversation in late October of 2018 I have created a git hub account and added my changes.  This branch adds a check that the set_auto_boot utility is running on machine with the correct chipset.  I also added and rc.d script.  The rc.d script works for me but I'm not 100% sure it's right.
Let me know if there is anything else you need to include this in your repo
Thank you again for your hep and for the original utility.
Christopher